### PR TITLE
Remove `toolchain` directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/pocke/itzpapalotl
 
 go 1.21
 
-toolchain go1.21.6
-
 require github.com/gorcon/rcon v1.3.4


### PR DESCRIPTION
Because goreleaser does not understand it

> ```
> /home/runner/work/itzpapalotl/itzpapalotl/go.mod:5: unknown directive: toolchain
> ```